### PR TITLE
Updated dynmotd to not divide by 0 or print battery info on desktops

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,8 +13,8 @@ To install this script, there are two major steps that need to be completed:
 
 When you open a new terminal, the new motd will be displayed.
 
-**Note:** Editing `/etc/profile` required root privileges.
-  
+**Note:** You can also move `dynmotd` to somewhere else on your path if you want.  Editing `/etc/profile` requires root privileges, but you can also add the line to `~/.bash_profile` replacing `/etc/dynmotd` with the path to `dynmotd`.  
+
 ## Next-Gen Message of the Day
 
 The `dynmotd` script outputs a bash file that looks like the following when executed. It supports colors and variables, and parses the output of `system_profiler SPFirewallDataType SPPowerDataType SPNetworkDataType SPSoftwareDataType` to obtain system pertinent information and stored it into flattened variables.
@@ -38,8 +38,24 @@ The `dynmotd` script outputs a bash file that looks like the following when exec
     Charging: No
     Percentage: 87.03823807594%
     Splugs-MacBook-Pro:~ splug$
+If you're on a desktop, you might see something like:
 
-  ![Example](http://www.highonphp.com/v3/wp-content/uploads/2013/06/Screen-Shot-2013-06-18-at-10.56.35-AM.png)
+      --  Hackintosh OS X --
+        macOS 10.13.5 (17F77)
+    
+    Network:
+    Hostname: Mac Mini
+    Addresses: 192.0.2.15
+    Next-Hop: 192.0.2.5
+    DNS Servers: 8.8.8.8, 8.8.4.4
+    en1: 192.0.2.15
+    Firewall: Allow all incoming connections
+
+    System:
+    Uptime: 12 days 56 minutes
+    Processor:  Intel(R) Core(TM) i5-3210M CPU @ 2.50GHz
+    
+<!--  ![Example](http://www.highonphp.com/v3/wp-content/uploads/2013/06/Screen-Shot-2013-06-18-at-10.56.35-AM.png)-->
   
 
   

--- a/dynmotd
+++ b/dynmotd
@@ -28,9 +28,12 @@ foreach($systemvars as $var){
 		}
 	}
 }
-
-$bp = round(($CHARGE_INFORMATION_CHARGE_REMAINING__MAH_/$CHARGE_INFORMATION_FULL_CHARGE_CAPACITY__MAH_)*100, 2);
-
+if ($CHARGE_INFORMATION_FULL_CHARGE_CAPACITY__MAH_ != 0){
+	$bp = round(($CHARGE_INFORMATION_CHARGE_REMAINING__MAH_/$CHARGE_INFORMATION_FULL_CHARGE_CAPACITY__MAH_)*100, 2);
+}
+else{
+	$bp = "";
+}
 
 $content = <<<CONTENTS
 #!/bin/bash
@@ -74,9 +77,18 @@ echo -e "\${EMG}Uptime\${W}: \${C}$SYSTEM_SOFTWARE_OVERVIEW_TIME_SINCE_BOOT\${NO
 echo -e "\${EMG}Processor\${W}: \${C}$(sysctl -a | grep "machdep.cpu.brand_string:" | cut -d':' -f2)\${NONE}"
 
 echo -e ""
-echo -e "\${EMW}Battery:\${NONE}"
-echo -e "\${EMG}Charging\${W}: \${C}$AC_CHARGER_INFORMATION_CHARGING\${NONE}"
-echo -e "\${EMG}Percentage\${W}: \${C}$bp%\${NONE}"
+if [ "$AC_CHARGER_INFORMATION_CHARGING" != "" ] || [ "$bp" != "" ]
+then
+	echo -e "\${EMW}Battery:\${NONE}"
+	if [ "$AC_CHARGER_INFORMATION_CHARGING" != "" ]
+	then
+		echo -e "\${EMG}Charging\${W}: \${C}$AC_CHARGER_INFORMATION_CHARGING\${NONE}"
+	fi
+	if [ "$bp" != "" ]
+	then
+		echo -e "\${EMG}Percentage\${W}: \${C}$bp%\${NONE}"
+	fi
+fi
 exit
 CONTENTS;
 


### PR DESCRIPTION
On desktops, calculating the battery percentage will cause a divide by 0 warning, & the battery info is useless, so I've added some if's to make it safer & more useful on desktops.  